### PR TITLE
Integrate OpenAI Responses

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+OPENAI_API_KEY=your-openai-key
+CONTEXT7_MCP_SERVER_URL=https://context7.example.com

--- a/README.md
+++ b/README.md
@@ -34,3 +34,13 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Environment Variables
+
+Create a `.env` file based on `.env.example` and provide your OpenAI API key and Context7 MCP server URL:
+
+```
+OPENAI_API_KEY=your-openai-key
+CONTEXT7_MCP_SERVER_URL=https://context7.example.com
+```
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "lucide-react": "^0.523.0",
         "next": "15.3.4",
         "next-themes": "^0.4.6",
+        "openai": "^5.9.0",
         "prismjs": "^1.30.0",
         "random-word-slugs": "^0.1.7",
         "react": "^19.0.0",
@@ -1451,9 +1452,9 @@
       }
     },
     "node_modules/@inngest/agent-kit": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@inngest/agent-kit/-/agent-kit-0.8.3.tgz",
-      "integrity": "sha512-mZcKFIAF8ZFkiKIvdtpT0EzlvhBuFO6XyDTptA1SX1fnZTtxhi5e47Ck+caAauFKRvmdlKJrnbIrRJk9sR6vPg==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@inngest/agent-kit/-/agent-kit-0.8.4.tgz",
+      "integrity": "sha512-xd7Ra5tKA3Dh6jHLcKot3cq5551xYA2ncn10hrAq5mzD6vsMaW711Uxn23jTuep2YyDUoRlIQFW1WAw7RbCWVw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dmitryrechkin/json-schema-to-zod": "^1.0.0",
@@ -10401,6 +10402,27 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openai": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.9.0.tgz",
+      "integrity": "sha512-cmLC0pfqLLhBGxE4aZPyRPjydgYCncppV2ClQkKmW79hNjCvmzkfhz8rN5/YVDmjVQlFV+UsF1JIuNjNgeagyQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/openapi-fetch": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "lucide-react": "^0.523.0",
     "next": "15.3.4",
     "next-themes": "^0.4.6",
+    "openai": "^5.9.0",
     "prismjs": "^1.30.0",
     "random-word-slugs": "^0.1.7",
     "react": "^19.0.0",

--- a/src/inngest/functions.ts
+++ b/src/inngest/functions.ts
@@ -1,5 +1,5 @@
 import { inngest } from "./client";
-import { createAgent, gemini, createTool, createNetwork, type Tool } from "@inngest/agent-kit";
+import { createAgent, openai, createTool, createNetwork, type Tool } from "@inngest/agent-kit";
 import  { Sandbox } from "@e2b/code-interpreter"
 import { getSandbox } from "./utils";
 import { z } from "zod";
@@ -31,9 +31,19 @@ export const codeAgentFunction = inngest.createFunction(
       name: "code-agent",
       description: "An expert coding agent",
       system: PROMPT,
-      model: gemini({
-        model: "gemini-1.5-flash", 
-        apiKey: process.env.GEMINI_API_KEY
+      model: openai({
+        model: "o4-mini",
+        apiKey: process.env.OPENAI_API_KEY,
+        defaultParameters: {
+          reasoning: { effort: "high" },
+          tools: [
+            {
+              type: "mcp",
+              server_label: "context7",
+              server_url: process.env.CONTEXT7_MCP_SERVER_URL || "",
+            },
+          ],
+        },
       }),
       tools: [                                                                       // Herramientas del agente de código
         


### PR DESCRIPTION
## Summary
- add environment variable example file
- document OpenAI configuration in README
- install `openai` dependency
- configure agent to use OpenAI responses API with o4-mini model and context7 MCP

## Testing
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_6870df55c3ec832883d8ba71bcb04262